### PR TITLE
Bugfix missing return value getLocaleLabelUsing 

### DIFF
--- a/src/FilamentAstrotomicTranslatablePlugin.php
+++ b/src/FilamentAstrotomicTranslatablePlugin.php
@@ -57,9 +57,11 @@ class FilamentAstrotomicTranslatablePlugin implements Plugin
         return app(Locales::class)->current();
     }
 
-    public function getLocaleLabelUsing(?Closure $callback): void
+    public function getLocaleLabelUsing(?Closure $callback): static
     {
         $this->getLocaleLabelUsing = $callback;
+
+        return $this;
     }
 
     public function getLocaleLabel(string $locale, ?string $displayLocale = null): ?string


### PR DESCRIPTION
Merge this will make getLocaleLabelUsing work as expected. 
So you can do something like this:
```
FilamentAstrotomicTranslatablePlugin::make()
  ->getLocaleLabelUsing(function ($locale) {
      return match ($locale) {
          'en' => 'English',
          'es' => 'Spanish',
          'br' => 'Brazil',
          'pe' => 'Peru',
          default => $locale,
      };
  }),
```